### PR TITLE
fsctl.c: it is _WIN32_WINNT, not WIN32_WINNT. ReactOS CORE-12589

### DIFF
--- a/src/fsctl.c
+++ b/src/fsctl.c
@@ -5061,7 +5061,7 @@ NTSTATUS fsctl_request(PDEVICE_OBJECT DeviceObject, PIRP* Pirp, UINT32 type) {
             Status = STATUS_INVALID_DEVICE_REQUEST;
             break;
 
-#if WIN32_WINNT >= 0x0600
+#if _WIN32_WINNT >= 0x0600
         case FSCTL_MAKE_MEDIA_COMPATIBLE:
             WARN("STUB: FSCTL_MAKE_MEDIA_COMPATIBLE\n");
             Status = STATUS_INVALID_DEVICE_REQUEST;


### PR DESCRIPTION
## Purpose

Fix a typo.

JIRA issue: [ReactOS CORE-12589](https://jira.reactos.org/browse/CORE-12589)

## Proposed changes

See [ReactOS CORE-12589 comment](https://jira.reactos.org/browse/CORE-12589?focusedCommentId=87680&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-87680).